### PR TITLE
Fix initial comment line

### DIFF
--- a/mx-report.py
+++ b/mx-report.py
@@ -1,4 +1,4 @@
-# mx_domain_analyzer.py
+# mx-report.py
 # A script to analyze domain MX records, SPF, DMARC, and DKIM settings.
 #
 # To run this script, you'll need to install the dnspython library:


### PR DESCRIPTION
## Summary
- rename script comment from mx_domain_analyzer.py to mx-report.py

## Testing
- `python -m py_compile mx-report.py` *(fails: SyntaxError: f-string: unmatched '[')*

------
https://chatgpt.com/codex/tasks/task_e_683f893d4e14833389ae96e81311eea6